### PR TITLE
Remove unnecessary UnreadRune call.

### DIFF
--- a/shlex.go
+++ b/shlex.go
@@ -253,7 +253,6 @@ func (t *Tokenizer) scanStream() (*Token, error) {
 					}
 				case spaceRuneClass:
 					{
-						t.input.UnreadRune()
 						token := &Token{
 							tokenType: tokenType,
 							value:     string(value)}


### PR DESCRIPTION
Because space tokens are simply ignored.